### PR TITLE
cleanup-runtime-parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/election_anomaly/db_routines/create_cdf_db/__pycache__/__init__.cpython-37.p
 dist
 *.egg-info
 build
+.ini

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ src/election_anomaly/db_routines/create_cdf_db/__pycache__/__init__.cpython-37.p
 dist
 *.egg-info
 build
-.ini
+*.ini

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ src/election_anomaly/db_routines/create_cdf_db/__pycache__/__init__.cpython-37.p
 dist
 *.egg-info
 build
-*.ini
+*.par

--- a/docs/sample_session.rtf
+++ b/docs/sample_session.rtf
@@ -1,0 +1,113 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2513
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Oblique;\f1\fswiss\fcharset0 Helvetica-Bold;\f2\fswiss\fcharset0 Helvetica;
+}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\margl1440\margr1440\vieww17920\viewh7560\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\i\fs28 \cf0 	Sample transcript for session to install and run the system from the command line. User in put 
+\f1\i0\b in bold
+\f0\i\b0 . Comments in italics.
+\f2\i0\fs24 \
+ \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\i\fs28 \cf0 	Create directory for the system
+\f2\i0\fs24 .\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\fs28 \cf0 % 
+\f1\b mkdir my_election_anomaly_finder\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\i\b0 \cf0 \
+	Navigate to directory and clone repository. This creates a repository subdirectory called 'election_anomaly'
+\f2\i0\fs24 . 
+\fs28 \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0  % 
+\f1\b cd my_election_anomaly_finder
+\f2\b0  \
+ my_election_anomaly_finder % 
+\f1\b git clone https://github.com/sfsinger19103/election_anomaly.git
+\f2\b0\fs24 \
+Cloning into 'election_anomaly'...\
+remote: Enumerating objects: 431, done.\
+remote: Counting objects: 100% (431/431), done.\
+remote: Compressing objects: 100% (235/235), done.\
+remote: Total 9791 (delta 235), reused 333 (delta 169), pack-reused 9360\
+Receiving objects: 100% (9791/9791), 30.26 MiB | 4.89 MiB/s, done.\
+Resolving deltas: 100% (5546/5546), done.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\i\fs28 \cf0 \
+	Get election results data from the election agency (here it's the general results by precinct from North Carolina 2018)
+\f2\i0\fs24 .\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\fs28 \cf0  my_election_anomaly_finder % 
+\f1\b wget https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2018_11_06/provisional_20181106.txt
+\f2\b0 \
+
+\fs24 --2020-06-19 14:08:12--  https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2018_11_06/provisional_20181106.txt\
+Resolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.98.45\
+Connecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.98.45|:443... connected.\
+HTTP request sent, awaiting response... 200 OK\
+Length: 12807164 (12M) [text/plain]\
+Saving to: \'91provisional_20181106.txt\'92\
+\
+provisional_20181106. 100%[========================>]  12.21M  5.04MB/s    in 2.4s    \
+\
+2020-06-19 14:08:15 (5.04 MB/s) - \'91provisional_20181106.txt\'92 saved [12807164/12807164]\
+
+\f0\i\fs28 \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 	Navigate into repository subdirectory and install the system, then navigate back to the parent directory
+\f2\i0\fs24 .\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\fs28 \cf0 my_election_anomaly_finder % 
+\f1\b cd election_anomaly
+\f2\b0          \
+ election_anomaly % 
+\f1\b python3 setup.py install
+\f2\b0 \
+
+\fs24 running install\
+running bdist_egg\
+running egg_info\
+\
+
+\f0\i\fs28 			... and lots more diagnostic output
+\f2\i0\fs24 \
+\
+Using /usr/local/lib/python3.7/site-packages\
+Finished processing dependencies for election-anomaly==0.1\
+
+\fs28  election_anomaly % 
+\f1\b cd ..
+\f2\b0 \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\i \cf0 \
+	Using whatever editor you like, create a file called 'run_time.par` in the 'election_anomaly' directory using 'election_anomaly/src/templates/parameter_file_templates/run_time.par' as a template. For instance, replace '<path to project root>' with the path to your current directory, so the line will look like this:\
+				
+\f2\i0 project_root=/Users/sfsinger/Temp/my_election_anomaly_finder
+\fs24 \
+
+\f0\i\fs28 Do not use spaces or quotes.
+\f2\i0\fs24 \
+
+\f0\i\fs28 \
+	Once the run_time.par file exists, you can run any routine in main_routines, e.g.:
+\f2\i0\fs24  \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\fs28 \cf0  my_election_anomaly_finder % 
+\f1\b python3 election_anomaly/src/election_anomaly/main_routines/050_load_datafile.py
+\f2\b0  \
+
+\fs24 \
+\
+}

--- a/src/election_anomaly/main_routines/010_check_jurisdiction.py
+++ b/src/election_anomaly/main_routines/010_check_jurisdiction.py
@@ -3,7 +3,7 @@ from election_anomaly import user_interface as ui
 
 
 if __name__ == '__main__':
-	d = ui.get_runtime_parameters(['project_root','juris_name'])
+	d, error = ui.get_runtime_parameters(['project_root','juris_name'])
 	j_path = os.path.join(d['project_root'],'jurisdictions')
 
 	juris = ui.pick_juris_from_filesystem(

--- a/src/election_anomaly/main_routines/020_load_jurisdiction_to_db.py
+++ b/src/election_anomaly/main_routines/020_load_jurisdiction_to_db.py
@@ -4,7 +4,7 @@ from election_anomaly import db_routines as dbr
 from sqlalchemy.orm import sessionmaker
 
 if __name__ == '__main__':
-	d = ui.get_runtime_parameters(
+	d, error = ui.get_runtime_parameters(
 		['project_root','juris_name','db_paramfile','db_name'])
 
 	j_path = os.path.join(d['project_root'],'jurisdictions')

--- a/src/election_anomaly/main_routines/030_check_munger_no_db.py
+++ b/src/election_anomaly/main_routines/030_check_munger_no_db.py
@@ -4,7 +4,7 @@ from election_anomaly import user_interface as ui
 
 if __name__ == '__main__':
 
-	d = ui.get_runtime_parameters(
+	d, error = ui.get_runtime_parameters(
 		['project_root','munger_name'])
 
 	# pick munger (nb: session=None by default, so info pulled from file system, not db)

--- a/src/election_anomaly/main_routines/031_check_munger_yes_db.py
+++ b/src/election_anomaly/main_routines/031_check_munger_yes_db.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 
 if __name__ == '__main__':
 
-	d = ui.get_runtime_parameters(
+	d, error = ui.get_runtime_parameters(
 		['project_root','db_paramfile','db_name','munger_name'])
 
 	# connect to db

--- a/src/election_anomaly/main_routines/040_check_datafile.py
+++ b/src/election_anomaly/main_routines/040_check_datafile.py
@@ -6,7 +6,7 @@ import os
 
 
 if __name__ == '__main__':
-	d = ui.get_runtime_parameters(
+	d, error = ui.get_runtime_parameters(
 		['project_root','results_file','db_paramfile','db_name','juris_name','munger_name'])
 
 	# initialize root widget for tkinter

--- a/src/election_anomaly/main_routines/050_load_datafile.py
+++ b/src/election_anomaly/main_routines/050_load_datafile.py
@@ -6,7 +6,7 @@ import os
 
 if __name__ == '__main__':
 
-	d = ui.get_runtime_parameters(
+	d, error = ui.get_runtime_parameters(
 		['project_root','juris_name','db_paramfile','db_name','munger_name','results_file'])
 
 	# pick jurisdiction

--- a/src/election_anomaly/main_routines/100_pull_top_counts_by_vote_type.py
+++ b/src/election_anomaly/main_routines/100_pull_top_counts_by_vote_type.py
@@ -7,7 +7,7 @@ from election_anomaly import analyze_via_pandas as avp
 
 # FIXME failed on CO 2018g by county, maybe issue with totals?
 if __name__ == '__main__':
-    d = ui.get_runtime_parameters(
+    d, error = ui.get_runtime_parameters(
         ['project_root','juris_name','db_paramfile','db_name','rollup_directory'])
     jurisdiction = ui.pick_juris_from_filesystem(
         d['project_root'],juriss_dir=os.path.join(

--- a/src/election_anomaly/main_routines/101_pull_top_counts.py
+++ b/src/election_anomaly/main_routines/101_pull_top_counts.py
@@ -6,7 +6,7 @@ from election_anomaly import user_interface as ui
 from election_anomaly import analyze_via_pandas as avp
 
 if __name__ == '__main__':
-    d = ui.get_runtime_parameters(
+    d, error = ui.get_runtime_parameters(
         ['project_root','juris_name','db_paramfile','db_name','rollup_directory'])
 
     jurisdiction = ui.pick_juris_from_filesystem(

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -801,7 +801,7 @@ def get_runtime_parameters(keys, param_file=None):
 	if param_file:
 		filename = param_file
 	else:
-		filename = 'run_time.ini'
+		filename = 'run_time.par'
 	parser.read(filename)
 
 	for k in keys:

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -794,35 +794,16 @@ def report_problems(problems,msg='There are problems'):
 
 
 def get_runtime_parameters(keys):
-	interact = input('Run interactively (y/n)?\n')
 	d = {}
-	if interact == 'y':
-		if 'project_root' in keys:
-			d['project_root'] = get_project_root()
-		if 'db_paramfile' in keys:
-			d['db_paramfile'] = pick_paramfile()
-		if 'db_name' in keys:
-			d['db_name'] = pick_database(d['project_root'],d['db_paramfile'])
-		if 'juris_name' in keys:
-			d['juris_name'] = None
-		if 'munger_name' in keys:
-			d['munger_name'] = None
-		if 'rollup_directory' in keys:
-			d['rollup_directory'] = pick_file_or_directory(
-				description='the directory for election result rollup exports',mode='directory')
-		if 'results_file' in keys:
-			d['results_file'] = pick_file_or_directory(description='the election results file',mode='file')
 
-		for k in [x for x in keys if x not in [
-			'project_root','db_paramfile','db_name','juris_name','rollup_directory']]:
-			d[k] = input(f'Enter {k}')
-	else:
-		d_from_file = config(section='election_anomaly',msg='Pick a paramfile.')
-		for k in keys:
-			try:
-				d[k] = d_from_file[k]
-			except KeyError:
-				print(f'Warning: no value found for {k} in the parameter file.')
+	parser = ConfigParser()
+	parser.read('run_time.ini')
+
+	for k in keys:
+		try:
+			d[k] = parser['election_anomaly'][k]
+		except KeyError:
+			print(f'Warning: no value found for {k} in the parameter file.')
 	for k in keys:
 		print(f'{k}: {d[k]}')
 	return d

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -795,6 +795,7 @@ def report_problems(problems,msg='There are problems'):
 
 def get_runtime_parameters(keys):
 	d = {}
+	missing_params = {'missing':[]}
 
 	parser = ConfigParser()
 	parser.read('run_time.ini')
@@ -803,7 +804,10 @@ def get_runtime_parameters(keys):
 		try:
 			d[k] = parser['election_anomaly'][k]
 		except KeyError:
-			print(f'Warning: no value found for {k} in the parameter file.')
-	for k in keys:
-		print(f'{k}: {d[k]}')
-	return d
+			missing_params['missing'].append(k)
+
+	if len(missing_params['missing']) == 0:
+		missing_params = None
+
+	return d, missing_params
+

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -793,12 +793,16 @@ def report_problems(problems,msg='There are problems'):
 	return
 
 
-def get_runtime_parameters(keys):
+def get_runtime_parameters(keys, param_file=None):
 	d = {}
 	missing_params = {'missing':[]}
 
 	parser = ConfigParser()
-	parser.read('run_time.ini')
+	if param_file:
+		filename = param_file
+	else:
+		filename = 'run_time.ini'
+	parser.read(filename)
 
 	for k in keys:
 		try:
@@ -810,4 +814,3 @@ def get_runtime_parameters(keys):
 		missing_params = None
 
 	return d, missing_params
-


### PR DESCRIPTION
This updates the `user_interface.get_runtime_parameter()` function with the following:
- Removes the interactive option
- Assumes that the run_time.ini file exists in the current (calling) directory, but adds support to accept the location as a parameter in the future
- Packages any missing parameters into a dictionary and returns the missing_params dictionary alongside the "successful" parameter dictionary
- When this function gets called, the 2 return values (successful and missing param dictionaries) get caught instead of just the single

See TODOs [here](https://electionanomaly.slack.com/archives/C0152LYENHK/p1592516285013600?thread_ts=1592516238.013400&cid=C0152LYENHK) and [here](https://electionanomaly.slack.com/archives/C0152LYENHK/p1592516303013800?thread_ts=1592516238.013400&cid=C0152LYENHK)