### PR TITLE
cleanup-database-connection

### DIFF
--- a/src/election_anomaly/db_routines/__init__.py
+++ b/src/election_anomaly/db_routines/__init__.py
@@ -84,18 +84,11 @@ def establish_connection(paramfile, db_name='postgres'):
     try:
         con = psycopg2.connect(**params)
     except psycopg2.OperationalError as e:
-        # ERIC: call the pick_database function from here?
-        # probably put it into this file instead of UI
-        # remove the default db_name in argument
-        # if we can't make a connection here return another message
-        # otherwise this function returns none
         return {'message': 'Unable to establish connection to database.'}
     con.close()
     return None
 
 
-#ERIC: can probs move this whole thing to the DBR file. Only
-#other place it's called is by the get_runtime_params, but that was deleted by other thing
 def create_new_db(project_root, paramfile, db_name):
     # get connection to default postgres DB to create new one
     try:    

--- a/src/election_anomaly/main_routines/050_load_datafile.py
+++ b/src/election_anomaly/main_routines/050_load_datafile.py
@@ -13,10 +13,7 @@ if __name__ == '__main__':
 	juris = ui.pick_juris_from_filesystem(d['project_root'],juris_name=d['juris_name'])
 
 	# create db if it does not already exist
-	con, paramfile = dbr.establish_connection(paramfile=d['db_paramfile'],db_name=d['db_name'])
-	if not con:
-		print(f'Database {d["db_name"]} not found, will be created.')
-		ui.pick_database(d['project_root'],paramfile=d['db_paramfile'],db_name=d['db_name'])
+	error = dbr.establish_connection(paramfile=d['db_paramfile'],db_name=d['db_name'])
 
 	# connect to db
 	eng = dbr.sql_alchemy_connect(paramfile=d['db_paramfile'],db_name=d['db_name'])

--- a/src/election_anomaly/main_routines/050_load_datafile.py
+++ b/src/election_anomaly/main_routines/050_load_datafile.py
@@ -14,6 +14,8 @@ if __name__ == '__main__':
 
 	# create db if it does not already exist
 	error = dbr.establish_connection(paramfile=d['db_paramfile'],db_name=d['db_name'])
+	if error:
+		dbr.create_new_db(d['project_root'], d['db_paramfile'], d['db_name'])
 
 	# connect to db
 	eng = dbr.sql_alchemy_connect(paramfile=d['db_paramfile'],db_name=d['db_name'])


### PR DESCRIPTION
This PR removes the interactivity in the load_datafile script. It assumes that the run-time parameters exists and work correctly due to work done in the `cleanup-runtime-parameters` branch (although those commits are not included in this branch). It performs the following:
- Returns an error message if it tries and fails to connect to the DB described in the parameter files
- If it finds an error, it connects to the default `postgres` database to create a new DB using the naming found in the parameter file
- If it can't connect to a database at all, it exits

A successful run-through means that the user will get to the "Skip jurisdiction loading info" step. If `n` is selected, then the script will try to interact with the existing or newly created DB.

See TODOs [here](https://electionanomaly.slack.com/archives/C0152LYENHK/p1592596827014100?thread_ts=1592516238.013400&cid=C0152LYENHK)
