### PR TITLE
create-dataloader-class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ SQLAlchemy==1.3.12
 easygui
 xlrd
 sqlalchemy_utils
-pprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ SQLAlchemy==1.3.12
 easygui
 xlrd
 sqlalchemy_utils
+pprint

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -53,7 +53,7 @@ class DataLoader():
             session=self.session,munger_name=self.d['munger_name'])
 
     
-    def data_load_errors(self):
+    def check_errors(self):
         juris_exists = None
         if not self.juris:
             juris_exists = {"juris_created": False}
@@ -62,7 +62,7 @@ class DataLoader():
             self.juris_load_err, self.munger_err
 
 
-    def fix_errors(self):
+    def reload_requirements(self):
         if self.session:
             self.session.close()
         if self.engine:

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -29,8 +29,11 @@ class DataLoader():
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
 
-        self.juris_load_err = self.juris.load_juris_to_db(self.session,
-            self.d['project_root'])
+        if self.juris:
+            self.juris_load_err = self.juris.load_juris_to_db(self.session,
+                self.d['project_root'])
+        else:
+            self.juris_load_err = None
 
         # pick munger
         self.munger, self.munger_err = ui.pick_munger(
@@ -52,6 +55,8 @@ class DataLoader():
         if self.juris_err:
             print("Jurisdiction file errors:")
             pprint(self.juris_err)
+        if not self.juris:
+            print("Jurisdiction object not created")
         if self.juris_load_err:
             print("Jurisdiction loading errors:")
             pprint(self.juris_load_err)

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -24,9 +24,9 @@ class DataLoader():
                 self.d['db_name'])
 
         # connect to db
-        eng = dbr.sql_alchemy_connect(paramfile=self.d['db_paramfile'],
+        self.engine = dbr.sql_alchemy_connect(paramfile=self.d['db_paramfile'],
             db_name=self.d['db_name'])
-        Session = sessionmaker(bind=eng)
+        Session = sessionmaker(bind=self.engine)
         self.session = Session()
 
         self.juris_load_err = self.juris.load_juris_to_db(self.session,
@@ -37,3 +37,55 @@ class DataLoader():
             project_root=self.d['project_root'],
             mungers_dir=os.path.join(self.d['project_root'],'mungers'),
             session=self.session,munger_name=self.d['munger_name'])
+
+        pprint(self.parameter_err)
+        pprint(self.juris_err)
+        pprint(self.juris_load_err)
+        pprint(self.munger_err) 
+        print("done!")
+
+    
+    def data_load_errors(self):
+        if self.parameter_err:
+            print("Parameter errors:")
+            pprint(self.parameter_err)
+        if self.juris_err:
+            print("Jurisdiction file errors:")
+            pprint(self.juris_err)
+        if self.juris_load_err:
+            print("Jurisdiction loading errors:")
+            pprint(self.juris_load_err)
+        if self.munger_err:
+            print("Munger file errors:")
+            pprint(self.munger_err) 
+
+
+    def fix_errors(self):
+        if self.session:
+            self.session.close()
+        if self.engine:
+            self.engine.dispose()
+
+        self.d, self.parameter_err = ui.get_runtime_parameters(
+            ['project_root','juris_name','db_paramfile',
+            'db_name','munger_name','results_file'])
+
+        # pick jurisdiction
+        self.juris, self.juris_err = ui.pick_juris_from_filesystem(
+            self.d['project_root'],juris_name=self.d['juris_name'],check_files=True)
+
+        # create db if it does not already exist
+        error = dbr.establish_connection(paramfile=self.d['db_paramfile'],
+            db_name=self.d['db_name'])
+        if error:
+            dbr.create_new_db(self.d['project_root'], self.d['db_paramfile'], 
+                self.d['db_name'])
+
+        # connect to db
+        eng = dbr.sql_alchemy_connect(paramfile=self.d['db_paramfile'],
+            db_name=self.d['db_name'])
+        Session = sessionmaker(bind=eng)
+        self.session = Session()
+
+        self.juris_load_err = self.juris.load_juris_to_db(self.session,
+            self.d['project_root'])    

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -6,22 +6,31 @@ from pprint import pprint
 import sys
 
 class DataLoader():
-    def __init__(self):
-        # grab parameters
+    def __new__(self):
+        """ Checks if parameter file exists and is correct. If not, does
+        not create DataLoader object. """
         try:
-            self.d, self.parameter_err = ui.get_runtime_parameters(
+            d, parameter_err = ui.get_runtime_parameters(
                 ['project_root','juris_name','db_paramfile',
                 'db_name','munger_name','results_file'])
         except FileNotFoundError as e:
             print("Parameter file not found. Ensure that it is located" \
-                " in the current directory. Exiting.")
-            sys.exit()
+                " in the current directory. DataLoader object not created.")
+            return None
 
-        if self.parameter_err:
+        if parameter_err:
             print("Parameter file missing requirements.")
-            print(self.parameter_err)
-            print("Exiting")
-            sys.exit()
+            print(parameter_err)
+            print("DataLoader object not created.")
+            return None
+
+        return super().__new__(self)
+
+    def __init__(self):
+        # grab parameters
+        self.d, self.parameter_err = ui.get_runtime_parameters(
+            ['project_root','juris_name','db_paramfile',
+            'db_name','munger_name','results_file'])
 
         # pick jurisdiction
         self.juris, self.juris_err = ui.pick_juris_from_filesystem(

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -3,14 +3,25 @@ from election_anomaly import user_interface as ui
 from sqlalchemy.orm import sessionmaker
 import os
 from pprint import pprint
+import sys
 
 class DataLoader():
     def __init__(self):
-        print("we're really doing it!")
+        # grab parameters
+        try:
+            self.d, self.parameter_err = ui.get_runtime_parameters(
+                ['project_root','juris_name','db_paramfile',
+                'db_name','munger_name','results_file'])
+        except FileNotFoundError as e:
+            print("Parameter file not found. Ensure that it is located" \
+                " in the current directory. Exiting.")
+            sys.exit()
 
-        self.d, self.parameter_err = ui.get_runtime_parameters(
-            ['project_root','juris_name','db_paramfile',
-            'db_name','munger_name','results_file'])
+        if self.parameter_err:
+            print("Parameter file missing requirements.")
+            print(self.parameter_err)
+            print("Exiting")
+            sys.exit()
 
         # pick jurisdiction
         self.juris, self.juris_err = ui.pick_juris_from_filesystem(
@@ -40,12 +51,6 @@ class DataLoader():
             project_root=self.d['project_root'],
             mungers_dir=os.path.join(self.d['project_root'],'mungers'),
             session=self.session,munger_name=self.d['munger_name'])
-
-        pprint(self.parameter_err)
-        pprint(self.juris_err)
-        pprint(self.juris_load_err)
-        pprint(self.munger_err) 
-        print("done!")
 
     
     def data_load_errors(self):

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -1,0 +1,39 @@
+from election_anomaly import db_routines as dbr
+from election_anomaly import user_interface as ui
+from sqlalchemy.orm import sessionmaker
+import os
+from pprint import pprint
+
+class DataLoader():
+    def __init__(self):
+        print("we're really doing it!")
+
+        self.d, self.parameter_err = ui.get_runtime_parameters(
+            ['project_root','juris_name','db_paramfile',
+            'db_name','munger_name','results_file'])
+
+        # pick jurisdiction
+        self.juris, self.juris_err = ui.pick_juris_from_filesystem(
+            self.d['project_root'],juris_name=self.d['juris_name'],check_files=True)
+
+        # create db if it does not already exist
+        error = dbr.establish_connection(paramfile=self.d['db_paramfile'],
+            db_name=self.d['db_name'])
+        if error:
+            dbr.create_new_db(self.d['project_root'], self.d['db_paramfile'], 
+                self.d['db_name'])
+
+        # connect to db
+        eng = dbr.sql_alchemy_connect(paramfile=self.d['db_paramfile'],
+            db_name=self.d['db_name'])
+        Session = sessionmaker(bind=eng)
+        self.session = Session()
+
+        self.juris_load_err = self.juris.load_juris_to_db(self.session,
+            self.d['project_root'])
+
+        # pick munger
+        self.munger, self.munger_err = ui.pick_munger(
+            project_root=self.d['project_root'],
+            mungers_dir=os.path.join(self.d['project_root'],'mungers'),
+            session=self.session,munger_name=self.d['munger_name'])

--- a/src/election_anomaly/__init__.py
+++ b/src/election_anomaly/__init__.py
@@ -54,20 +54,12 @@ class DataLoader():
 
     
     def data_load_errors(self):
-        if self.parameter_err:
-            print("Parameter errors:")
-            pprint(self.parameter_err)
-        if self.juris_err:
-            print("Jurisdiction file errors:")
-            pprint(self.juris_err)
+        juris_exists = None
         if not self.juris:
-            print("Jurisdiction object not created")
-        if self.juris_load_err:
-            print("Jurisdiction loading errors:")
-            pprint(self.juris_load_err)
-        if self.munger_err:
-            print("Munger file errors:")
-            pprint(self.munger_err) 
+            juris_exists = {"juris_created": False}
+        
+        return self.parameter_err, self.juris_err, juris_exists, \
+            self.juris_load_err, self.munger_err
 
 
     def fix_errors(self):

--- a/src/election_anomaly/juris_and_munger/__init__.py
+++ b/src/election_anomaly/juris_and_munger/__init__.py
@@ -96,7 +96,6 @@ class Jurisdiction:
 
         with open(os.path.join(self.path_to_juris_dir,'remark.txt'),'r') as f:
             remark = f.read()
-        print(f'\n\nJurisdiction {short_name} initialized! Note:\n{remark}')
 
 
 class Munger:
@@ -211,10 +210,7 @@ class Munger:
         self.path_to_munger_dir = dir_path
 
         # create dir if necessary
-        if os.path.isdir(dir_path):
-            print(f'Directory {self.name} exists.')
-        else:
-            print(f'Creating directory {self.name}')
+        if not os.path.isdir(dir_path):
             Path(dir_path).mkdir(parents=True,exist_ok=True)
 
         if check_files:
@@ -706,7 +702,6 @@ def load_juris_dframe_into_cdf(session,element,juris_path,project_root,error,loa
 
             try:
                 df = get_ids_for_foreign_keys(session,df,element,fn,refs,load_refs,error)
-                print(f'Database foreign id assigned for each {fn} in {element}.')
             except ForeignKeyException as e:
                 if load_refs:
                     for r in refs:

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -222,9 +222,6 @@ def pick_juris_from_filesystem(project_root,juriss_dir='jurisdictions',juris_nam
 		juris_path = os.path.join(path_to_jurisdictions,juris_name)
 		missing_values = sf.ensure_jurisdiction_files(juris_path,project_root)
 
-
-	print(missing_values)
-	input()
 	# initialize the jurisdiction
 	if missing_values:
 		ss = None
@@ -708,7 +705,9 @@ def get_runtime_parameters(keys, param_file=None):
 		filename = param_file
 	else:
 		filename = 'run_time.par'
-	parser.read(filename)
+	p = parser.read(filename)
+	if len(p) == 0:
+		raise FileNotFoundError
 
 	for k in keys:
 		try:

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -221,12 +221,12 @@ def pick_juris_from_filesystem(project_root,juriss_dir='jurisdictions',juris_nam
 	if check_files:
 		juris_path = os.path.join(path_to_jurisdictions,juris_name)
 		missing_values = sf.ensure_jurisdiction_files(juris_path,project_root)
-	# else:
-	# 	print(
-	# 		f'WARNING: if necessary files are missing from the directory {juris_name},\nsystem may fail.')
 
 	# initialize the jurisdiction
-	ss = sf.Jurisdiction(juris_name,path_to_jurisdictions)
+	if not missing_values:
+		ss = None
+	else:
+		ss = sf.Jurisdiction(juris_name,path_to_jurisdictions)
 	return ss, missing_values
 
 

--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -222,8 +222,11 @@ def pick_juris_from_filesystem(project_root,juriss_dir='jurisdictions',juris_nam
 		juris_path = os.path.join(path_to_jurisdictions,juris_name)
 		missing_values = sf.ensure_jurisdiction_files(juris_path,project_root)
 
+
+	print(missing_values)
+	input()
 	# initialize the jurisdiction
-	if not missing_values:
+	if missing_values:
 		ss = None
 	else:
 		ss = sf.Jurisdiction(juris_name,path_to_jurisdictions)

--- a/src/test-class.py
+++ b/src/test-class.py
@@ -1,0 +1,4 @@
+from election_anomaly import DataLoader
+
+dataloader = DataLoader()
+dataloader.data_load_errors()

--- a/src/test-class.py
+++ b/src/test-class.py
@@ -1,4 +1,0 @@
-from election_anomaly import DataLoader
-
-dataloader = DataLoader()
-dataloader.data_load_errors()


### PR DESCRIPTION
Creates the initial DataLoader class. Provides functionality to:

1. Create a DataLoader object, which performs the parameter, DB, jurisdiction, and munger checking and/or loading that we have been working on using `dataloader=DataLoader()`.
2. Check for any errors that were found as result of step one using `dataloader.check_errors()`.
3. Allow the user to retry all the setup if errors are found (once the errors are addressed by the user) using `dataloader.reload_requirements()`.

The idea is that there will be two additional functions in here: one to load the metadata for the results file into the DB and another to kick off the actual loading process for the results file. These will be created as separate PRs.