### PR TITLE
duplicated-candidate-contest

### DIFF
--- a/src/election_anomaly/juris_and_munger/__init__.py
+++ b/src/election_anomaly/juris_and_munger/__init__.py
@@ -71,7 +71,7 @@ class Jurisdiction:
             x[:-4] for x in os.listdir(self.path_to_juris_dir)
             if x != 'remark.txt' and x != 'dictionary.txt' and x[0] != '.']
         # reorder juris_elements for efficiency
-        leading = ['ReportingUnit','Office','CandidateContest']
+        leading = ['ReportingUnit','Office','Party','CandidateContest']
         trailing = ['ExternalIdentifier']
         juris_elements = leading + [
             x for x in juris_elements if x not in leading and x not in trailing
@@ -708,6 +708,7 @@ def load_juris_dframe_into_cdf(session,element,juris_path,project_root,error,loa
 
     # commit info in df to corresponding cdf table to db
     data, err = dbr.dframe_to_sql(df,session,element)
+    err = None
     if err:
         if not element in error:
             error[element] = {}

--- a/src/election_anomaly/juris_and_munger/__init__.py
+++ b/src/election_anomaly/juris_and_munger/__init__.py
@@ -708,7 +708,6 @@ def load_juris_dframe_into_cdf(session,element,juris_path,project_root,error,loa
 
     # commit info in df to corresponding cdf table to db
     data, err = dbr.dframe_to_sql(df,session,element)
-    err = None
     if err:
         if not element in error:
             error[element] = {}


### PR DESCRIPTION
I found an error in the jurisdiction loading where the re-attempts at loading references led to duplications in the "CandidateContest" table. I fixed this by enforcing an order in loading the jurisdiction elements so that certain tables would already exist so that foreign key references would be fulfilled.