### PR TITLE
better error messages

### DIFF
--- a/src/election_anomaly/user_interface/__init__.py
+++ b/src/election_anomaly/user_interface/__init__.py
@@ -614,6 +614,9 @@ def get_runtime_parameters(required_keys, optional_keys=None, param_file="multi.
 
     if not missing_required_params["missing"]:
         missing_required_params = None
+    else:
+        missing_required_params[f'missing parameter from {param_file}'] = missing_required_params.pop("missing")
+
 
     return d, missing_required_params
 

--- a/src/templates/parameter_file_templates/multi.par
+++ b/src/templates/parameter_file_templates/multi.par
@@ -7,3 +7,4 @@ archive_dir=</path/to/folder/for/archiving/uploaded/files>
 top_reporting_unit=<Name of state or other jurisdiction>
 sub_reporting_unit_type=<typically county>
 rollup_directory=</path/to/folder/for/storing/rolled-up/results>
+results_file=<just the name, not the path. File should be in the same directory as this parameter file>


### PR DESCRIPTION

1) The error messages tell what parameters are missing but don't specify from which file the parameters are missing. 
	
	Before:
	Parameter file missing requirements.
	{'missing': ['results_file']}
	Analyzer object not created.
	
	 After: 
	Parameter file missing requirements.
	{'missing parameter from multi.par': ['results_file']}
	 
2) Added results_file parameter to multi.par